### PR TITLE
Add new API to get HTTP response headers from last REST call

### DIFF
--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -30,12 +30,13 @@ type ErrorResponse struct {
 
 // OauthClient represents a stateful Oauth client
 type OauthClient struct {
-	Service      string
-	Client       *http.Client
-	Headers      map[string]string
-	ClientID     string
-	ClientSecret string
-	SourceHeader string
+	Service         string
+	Client          *http.Client
+	Headers         map[string]string
+	ClientID        string
+	ClientSecret    string
+	SourceHeader    string
+	ResponseHeaders http.Header
 }
 
 // OauthConfig represents configuration used to create Oauth clients
@@ -183,16 +184,23 @@ func (c *OauthClient) postAndGetBody(method string, args map[string]string) ([]b
 
 	httpresp, err := c.Client.Do(postreq)
 	if err != nil {
+		c.ResponseHeaders = nil
 		return nil, 0, err
 	}
 
 	defer httpresp.Body.Close()
+	c.ResponseHeaders = httpresp.Header
 
 	body, err := ioutil.ReadAll(httpresp.Body)
 	if err != nil {
 		return nil, httpresp.StatusCode, err
 	}
 	return body, httpresp.StatusCode, nil
+}
+
+// GetLastResponseHeaders returns the response header for the previous REST call
+func (c *OauthClient) GetLastResponseHeaders() http.Header {
+	return c.ResponseHeaders
 }
 
 func payloadFromMap(input map[string]string) string {

--- a/restapi/restapi.go
+++ b/restapi/restapi.go
@@ -38,8 +38,8 @@ type GenericMapResponse struct {
 }
 
 type HttpError struct {
-    error               // error type
-    StatusCode  int     // HTTP status
+	error          // error type
+	StatusCode int // HTTP status
 }
 
 // BackendType is the type of backend that is being implemented
@@ -47,10 +47,11 @@ type RestClientMode uint32
 
 // RestClient represents a stateful API client (cookies maintained between calls, single service etc)
 type RestClient struct {
-	Service      string
-	Client       *http.Client
-	Headers      map[string]string
-	SourceHeader string
+	Service         string
+	Client          *http.Client
+	Headers         map[string]string
+	SourceHeader    string
+	ResponseHeaders http.Header
 }
 
 // GetNewRestClient creates a new RestClient for the specified endpoint.  If a factory for creating
@@ -139,10 +140,14 @@ func (r *RestClient) postAndGetBody(method string, args map[string]interface{}) 
 
 	httpresp, err := r.Client.Do(postreq)
 	if err != nil {
+		r.ResponseHeaders = nil
 		return nil, err
 	}
 
 	defer httpresp.Body.Close()
+
+	// save response heasder
+	r.ResponseHeaders = httpresp.Header
 
 	if httpresp.StatusCode == 200 {
 		return ioutil.ReadAll(httpresp.Body)
@@ -150,6 +155,11 @@ func (r *RestClient) postAndGetBody(method string, args map[string]interface{}) 
 
 	body, _ := ioutil.ReadAll(httpresp.Body)
 	return nil, &HttpError{error: fmt.Errorf("POST to %s failed with code %d, body: %s", method, httpresp.StatusCode, body), StatusCode: httpresp.StatusCode}
+}
+
+// GetLastResponseHeaders returns the response headers from last REST call
+func (r *RestClient) GetLastResponseHeaders() http.Header {
+	return r.ResponseHeaders
 }
 
 // This function converts a map[string]interface{} into json string


### PR DESCRIPTION
Save HTTP response headers after a response is received from HTTP server, and provide new method, GetLastResponseHeaders, to access the headers.